### PR TITLE
add a Kalculator::Formula to act as a memoized formula

### DIFF
--- a/lib/kalculator.rb
+++ b/lib/kalculator.rb
@@ -2,23 +2,17 @@ require "rltk"
 require "kalculator/data_sources"
 require "kalculator/errors"
 require "kalculator/evaluator"
+require "kalculator/formula"
 require "kalculator/lexer"
 require "kalculator/parser"
 require "kalculator/version"
 
 class Kalculator
   def self.evaluate(formula, data_source = {})
-    new(formula).evaluate(data_source)
+    Kalculator::Formula.new(formula).evaluate(data_source)
   end
 
-  attr_reader :ast, :string
-
-  def initialize(string)
-    @ast = Kalculator::Parser.parse(Kalculator::Lexer.lex(string))
-    @string = string
-  end
-
-  def evaluate(data_source = {})
-    Kalculator::Evaluator.new(data_source).evaluate(ast)
+  def self.new(*args)
+    Kalculator::Formula.new(*args)
   end
 end

--- a/lib/kalculator/formula.rb
+++ b/lib/kalculator/formula.rb
@@ -1,0 +1,14 @@
+class Kalculator
+  class Formula
+    attr_reader :ast, :string
+
+    def initialize(string)
+      @ast = Kalculator::Parser.parse(Kalculator::Lexer.lex(string))
+      @string = string
+    end
+
+    def evaluate(data_source = {})
+      Kalculator::Evaluator.new(data_source).evaluate(ast)
+    end
+  end
+end

--- a/spec/built_in_functions_spec.rb
+++ b/spec/built_in_functions_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Kalculator do
+RSpec.describe Kalculator::Formula do
   describe "contains" do
     it "returns true when there is a match" do
       expect(Kalculator.evaluate("contains(\"ohai\", \"oh\")")).to eq(true)

--- a/spec/evaluate_spec.rb
+++ b/spec/evaluate_spec.rb
@@ -1,74 +1,74 @@
 RSpec.describe Kalculator do
   describe "Evaluation" do
     it "evaluates true" do
-      expect(Kalculator.new("true").evaluate).to be true
+      expect(Kalculator.evaluate("true")).to be true
     end
 
     it "evaluates false" do
-      expect(Kalculator.new("false").evaluate).to be false
+      expect(Kalculator.evaluate("false")).to be false
     end
 
     it "evaluates numbers" do
-      expect(Kalculator.new("18").evaluate).to eq(18)
+      expect(Kalculator.evaluate("18")).to eq(18)
     end
 
     it "evaluates addition" do
-      expect(Kalculator.new("9 + 9").evaluate).to eq(18)
+      expect(Kalculator.evaluate("9 + 9")).to eq(18)
     end
 
     it "evaluates subtraction" do
-      expect(Kalculator.new("9 - 3").evaluate).to eq(6)
+      expect(Kalculator.evaluate("9 - 3")).to eq(6)
     end
 
     it "evaluates multiplication" do
-      expect(Kalculator.new("9 * 3").evaluate).to eq(27)
+      expect(Kalculator.evaluate("9 * 3")).to eq(27)
     end
 
     it "evaluates division" do
-      expect(Kalculator.new("9 / 3").evaluate).to eq(3)
+      expect(Kalculator.evaluate("9 / 3")).to eq(3)
     end
 
     it "evaluates variables" do
-      expect(Kalculator.new("A").evaluate({"A" => 4})).to eq(4)
+      expect(Kalculator.evaluate("A", {"A" => 4})).to eq(4)
     end
 
     it "evaluates multi-part variable names" do
       data = {"A" => {"foo" => {"bar" => 14}}}
-      expect(Kalculator.new("A.foo.bar + 6").evaluate(data)).to eq(20)
+      expect(Kalculator.evaluate("A.foo.bar + 6", data)).to eq(20)
     end
 
     it "evaluates >" do
-      expect(Kalculator.new("4 > 4").evaluate).to eq(false)
-      expect(Kalculator.new("5 > 4").evaluate).to eq(true)
+      expect(Kalculator.evaluate("4 > 4")).to eq(false)
+      expect(Kalculator.evaluate("5 > 4")).to eq(true)
     end
 
     it "evaluates >=" do
-      expect(Kalculator.new("3 >= 4").evaluate).to eq(false)
-      expect(Kalculator.new("4 >= 4").evaluate).to eq(true)
+      expect(Kalculator.evaluate("3 >= 4")).to eq(false)
+      expect(Kalculator.evaluate("4 >= 4")).to eq(true)
     end
 
     it "evaluates <" do
-      expect(Kalculator.new("4 < 4").evaluate).to eq(false)
-      expect(Kalculator.new("4 < 5").evaluate).to eq(true)
+      expect(Kalculator.evaluate("4 < 4")).to eq(false)
+      expect(Kalculator.evaluate("4 < 5")).to eq(true)
     end
 
     it "evaluates <=" do
-      expect(Kalculator.new("4 <= 3").evaluate).to eq(false)
-      expect(Kalculator.new("4 <= 4").evaluate).to eq(true)
+      expect(Kalculator.evaluate("4 <= 3")).to eq(false)
+      expect(Kalculator.evaluate("4 <= 4")).to eq(true)
     end
 
     it "evaluates ==" do
-      expect(Kalculator.new("4 == 3").evaluate).to eq(false)
-      expect(Kalculator.new("4 == 4").evaluate).to eq(true)
+      expect(Kalculator.evaluate("4 == 3")).to eq(false)
+      expect(Kalculator.evaluate("4 == 4")).to eq(true)
     end
 
     it "evaluates if" do
-      expect(Kalculator.new("if(2 > 1, 1 + 1, 2 + 2)").evaluate).to eq(2)
-      expect(Kalculator.new("if(1 > 1, 1 + 1, 2 + 2)").evaluate).to eq(4)
+      expect(Kalculator.evaluate("if(2 > 1, 1 + 1, 2 + 2)")).to eq(2)
+      expect(Kalculator.evaluate("if(1 > 1, 1 + 1, 2 + 2)")).to eq(4)
     end
 
     it "evaluates sum" do
-      expect(Kalculator.new("sum(a)").evaluate({"a" => [1,2,3,4]})).to eq(10)
+      expect(Kalculator.evaluate("sum(a)", {"a" => [1,2,3,4]})).to eq(10)
     end
 
     it "can evaluate a string" do

--- a/spec/formula_spec.rb
+++ b/spec/formula_spec.rb
@@ -1,0 +1,6 @@
+RSpec.describe Kalculator::Formula do
+  it "memoizes the parsed formula string for faster evaluation" do
+    formula = Kalculator::Formula.new("1 + 2")
+    expect(formula.ast).to eq([:+, [:number, 1], [:number, 2]])
+  end
+end

--- a/spec/kalculator_spec.rb
+++ b/spec/kalculator_spec.rb
@@ -2,4 +2,8 @@ RSpec.describe Kalculator do
   it "has a shortcut for evaluating a formula directly" do
     expect(Kalculator.evaluate("1 + a", {"a" => 1})).to eq(2)
   end
+
+  it "has a backwards-compatible .new method for creating formulas" do
+    expect(Kalculator.new("1 + a").evaluate({"a" => 2})).to eq(3)
+  end
 end


### PR DESCRIPTION
After having some discussions with other engineers I realized that the name `Kalculator` doesn't seem to fit when we have an object that has a memoized copy of a particular AST. This seems to be more like a single `Formula` that can be run with different values. The performance gains of having memoized formulas rather than just calling `Kalculator.evaluate` is still important for some of my use-cases, but the name `Kalculator::Formula` better fits the idea of what that object does.