### PR TITLE
Flat names

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    kalculator (0.3.0)
+    kalculator (0.4.0)
       rltk (~> 3.0)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -3,6 +3,24 @@
 A rubygem to safely and quickly evaluate mathematical and logical expressions entered by a user.
 This library is very similar to [dentaku](https://github.com/rubysolo/dentaku) in purpose, but it emphasizes simplicity and performance.
 
+## Changes in 0.4.0
+
+Before 0.4.0 it was possible to pass in a multi-part name like:
+
+```ruby
+Kalculator.evaluate("a.b" => {"a" => {"b" => 15}}) # => 15
+```
+
+Looking up names this way restricts certain use-cases, so we've moved this functionality out of the way we evaluate and into a helper class.
+Now you can do either of the following:
+
+```
+# names are looked up in their complete form
+Kalculator.evaluate("a.b" => {"a.b" => 15}}) # => 15
+# the NestedLookup class splits names into parts and looks them up in a nested way
+Kalculator.evaluate("a.b" => Kalculator::NestedLookup.new({"a" => {"b" => 15}})) # => 15
+```
+
 ## Basic Usage
 
 ```ruby

--- a/lib/kalculator.rb
+++ b/lib/kalculator.rb
@@ -4,6 +4,7 @@ require "kalculator/errors"
 require "kalculator/evaluator"
 require "kalculator/formula"
 require "kalculator/lexer"
+require "kalculator/nested_lookup"
 require "kalculator/parser"
 require "kalculator/version"
 

--- a/lib/kalculator/evaluator.rb
+++ b/lib/kalculator/evaluator.rb
@@ -81,11 +81,9 @@ class Kalculator
       array.inject(0){|sum, num| sum + num}
     end
 
-    def variable(_, names)
-      names.inject(@data_source) do |source, name|
-        raise UndefinedVariableError, "undefined variable #{names.join(".")} (could not find #{name} in #{source}" unless source.key?(name)
-        source[name]
-      end
+    def variable(_, name)
+      raise UndefinedVariableError, "undefined variable #{name} (could not find #{name})" unless @data_source.key?(name)
+      @data_source[name]
     end
   end
 end

--- a/lib/kalculator/evaluator.rb
+++ b/lib/kalculator/evaluator.rb
@@ -82,7 +82,7 @@ class Kalculator
     end
 
     def variable(_, name)
-      raise UndefinedVariableError, "undefined variable #{name} (could not find #{name})" unless @data_source.key?(name)
+      raise UndefinedVariableError, "undefined variable #{name}" unless @data_source.key?(name)
       @data_source[name]
     end
   end

--- a/lib/kalculator/nested_lookup.rb
+++ b/lib/kalculator/nested_lookup.rb
@@ -1,0 +1,25 @@
+class Kalculator
+  class NestedLookup
+    def initialize(data_source)
+      @data_source = data_source
+    end
+
+    def key?(name)
+      names = name.split(".")
+      source = @data_source
+      names.all? do |name|
+        break false unless source.key?(name)
+        source = source[name]
+        true
+      end
+    end
+
+    def [](name)
+      names = name.split(".")
+      names.inject(@data_source) do |source, name|
+        break nil unless source.key?(name)
+        source[name]
+      end
+    end
+  end
+end

--- a/lib/kalculator/parser.rb
+++ b/lib/kalculator/parser.rb
@@ -20,7 +20,7 @@ class Kalculator
 
       clause('NUMBER') { |n| [:number, n] }
       clause('STRING') { |s| [:string, s] }
-      clause('IDENT') { |n| [:variable, n.split(".")] }
+      clause('IDENT') { |n| [:variable, n] }
       clause('TRUE') { |n| [:boolean, true] }
       clause('FALSE') { |n| [:boolean, false] }
 

--- a/lib/kalculator/version.rb
+++ b/lib/kalculator/version.rb
@@ -1,3 +1,3 @@
 class Kalculator
-  VERSION = "0.3.0"
+  VERSION = "0.4.0"
 end

--- a/spec/evaluate_spec.rb
+++ b/spec/evaluate_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Kalculator do
     end
 
     it "evaluates multi-part variable names" do
-      data = {"A" => {"foo" => {"bar" => 14}}}
+      data = {"A.foo.bar" => 14}
       expect(Kalculator.evaluate("A.foo.bar + 6", data)).to eq(20)
     end
 

--- a/spec/evaluate_spec.rb
+++ b/spec/evaluate_spec.rb
@@ -37,6 +37,12 @@ RSpec.describe Kalculator do
       expect(Kalculator.evaluate("A.foo.bar + 6", data)).to eq(20)
     end
 
+    it "evaluates nested multi-part variable names" do
+      data = {"A" => {"foo" => {"bar" => 14}}}
+      nested = Kalculator::NestedLookup.new(data)
+      expect(Kalculator.evaluate("A.foo.bar + 6", nested)).to eq(20)
+    end
+
     it "evaluates >" do
       expect(Kalculator.evaluate("4 > 4")).to eq(false)
       expect(Kalculator.evaluate("5 > 4")).to eq(true)

--- a/spec/evaluate_spec.rb
+++ b/spec/evaluate_spec.rb
@@ -43,6 +43,12 @@ RSpec.describe Kalculator do
       expect(Kalculator.evaluate("A.foo.bar + 6", nested)).to eq(20)
     end
 
+    it "missing names in a nested structure raise UndefinedVariableErrors" do
+      data = {"A" => {"foo" => {"bar" => 14}}}
+      nested = Kalculator::NestedLookup.new(data)
+      expect{ Kalculator.evaluate("A.foo.baz + 6", nested) }.to raise_error(Kalculator::UndefinedVariableError, "undefined variable A.foo.baz")
+    end
+
     it "evaluates >" do
       expect(Kalculator.evaluate("4 > 4")).to eq(false)
       expect(Kalculator.evaluate("5 > 4")).to eq(true)

--- a/spec/nested_lookup_spec.rb
+++ b/spec/nested_lookup_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe Kalculator::NestedLookup do
+  it "allows for nested key checks" do
+    nested = Kalculator::NestedLookup.new({"a" => {"b" => {"c" => 15, "d" => 16}, "e" => 17}})
+    expect(nested.key?("a")).to be true
+    expect(nested.key?("a.b")).to be true
+    expect(nested.key?("a.b.c")).to be true
+    expect(nested.key?("a.b.d")).to be true
+    expect(nested.key?("a.e")).to be true
+    expect(nested.key?("b")).to be false
+    expect(nested.key?("a.c")).to be false
+  end
+
+  it "allows for nested lookups" do
+    nested = Kalculator::NestedLookup.new({"a" => {"b" => {"c" => 15, "d" => 16}, "e" => 17}})
+    expect(nested["a"]).to eq({"b" => {"c" => 15, "d" => 16}, "e" => 17})
+    expect(nested["a.b"]).to eq({"c" => 15, "d" => 16})
+    expect(nested["a.b.c"]).to eq 15
+    expect(nested["a.b.d"]).to be 16
+    expect(nested["a.e"]).to be 17
+    expect(nested["b"]).to be nil
+    expect(nested["a.c"]).to be nil
+  end
+end

--- a/spec/parsing_spec.rb
+++ b/spec/parsing_spec.rb
@@ -17,12 +17,12 @@ RSpec.describe Kalculator do
 
     it "parses variable names" do
       calc = Kalculator.new("1 + TotalPrice")
-      expect(calc.ast).to eq([:+, [:number, 1], [:variable, ["TotalPrice"]]])
+      expect(calc.ast).to eq([:+, [:number, 1], [:variable, "TotalPrice"]])
     end
 
     it "parses variable names with dots in them for nested structures" do
       calc = Kalculator.new("a.foo + B.Bar")
-      expect(calc.ast).to eq([:+, [:variable, ["a","foo"]], [:variable, ["B","Bar"]]])
+      expect(calc.ast).to eq([:+, [:variable, "a.foo"], [:variable, "B.Bar"]])
     end
   end
 end


### PR DESCRIPTION
I came across a use-case where it was easiest to use an un-nested hash with keys like `"a.b.c."` rather than using nested hashes. This made it easy to doing memoization and dependency resolution across a set of calculations.

So I'm changing the library to resolve names in a flat way and adding a helper class that lets people wrap up their nested data sources and keep using them.