### PR TITLE
support basic AST transforms that walk the tree for you

### DIFF
--- a/lib/kalculator.rb
+++ b/lib/kalculator.rb
@@ -6,6 +6,7 @@ require "kalculator/formula"
 require "kalculator/lexer"
 require "kalculator/nested_lookup"
 require "kalculator/parser"
+require "kalculator/transform"
 require "kalculator/version"
 
 class Kalculator
@@ -15,5 +16,9 @@ class Kalculator
 
   def self.new(*args)
     Kalculator::Formula.new(*args)
+  end
+
+  def self.parse(formula)
+    Kalculator::Parser.parse(Kalculator::Lexer.lex(formula))
   end
 end

--- a/lib/kalculator/transform.rb
+++ b/lib/kalculator/transform.rb
@@ -1,0 +1,15 @@
+class Kalculator
+  module Transform
+    def self.run(node, &block)
+      new_node = yield node
+      return new_node if is_terminal?(new_node)
+      args = new_node[1..-1].map{ |arg| run(arg, &block) }
+      args.unshift(new_node.first)
+    end
+
+    def self.is_terminal?(node)
+      return false if node.is_a?(Array) && node.first.is_a?(Symbol)
+      true
+    end
+  end
+end

--- a/spec/kalculator_spec.rb
+++ b/spec/kalculator_spec.rb
@@ -6,4 +6,8 @@ RSpec.describe Kalculator do
   it "has a backwards-compatible .new method for creating formulas" do
     expect(Kalculator.new("1 + a").evaluate({"a" => 2})).to eq(3)
   end
+
+  it "has a shortcut for parsing" do
+    expect(Kalculator.parse("1 + 1")).to eq([:+, [:number, 1], [:number, 1]])
+  end
 end

--- a/spec/transforms_spec.rb
+++ b/spec/transforms_spec.rb
@@ -1,0 +1,50 @@
+require "spec_helper"
+
+RSpec.describe Kalculator::Transform do
+  it "can walk through an entire AST" do
+    ast = Kalculator.parse("sum(List)")
+    new_ast = Kalculator::Transform.run(ast) do |node|
+      if node == [:variable, "List"]
+        [:list, [[:number, 1], [:number, 2]]]
+      else
+        node
+      end
+    end
+    expect(new_ast).to eq([:sum, [:list, [[:number, 1], [:number, 2]]]])
+  end
+
+  it "can replace nested nodes" do
+    ast = Kalculator.parse("NotBlacklisted AND deal_splits.Revenue.user_id == rep.id")
+    new_ast = Kalculator::Transform.run(ast) do |node|
+      if node.size == 3 && node[1].first == :variable && node[1].last.split(".").size == 3
+        (_, type, column) = node[1].last.split(".")
+        [:and,
+          [node.first,
+            [:variable, "deal_splits.#{column}"],
+            node[2],
+          ],
+          [:==,
+            [:variable, "deal_split_type.name"],
+            [:string, type],
+          ],
+        ]
+      else
+        node
+      end
+    end
+
+    expect(new_ast).to eq([:and,
+      [:variable, "NotBlacklisted"],
+      [:and,
+        [:==,
+          [:variable, "deal_splits.user_id"],
+          [:variable, "rep.id"],
+        ],
+        [:==,
+          [:variable, "deal_split_type.name"],
+          [:string, "Revenue"],
+        ]
+      ]
+    ])
+  end
+end


### PR DESCRIPTION
Add a helper parsing a string into an AST and a helper for performing AST transformations.

In my usage of this gem, we often parse expression into an AST and then do a little bit of transformation on the AST before evaluating it. For instance, we might take variables like `[:variable, "line_item.id"]` and transform them to `[:variable, "line_items.123.line_item.id"]` when we are running that expression for a particular line item.

After writing the code a few times to walk through an AST looking for a particular pattern I thought it be better to just make this helper function in the gem that will walk an AST yielding each node and replacing parts of the tree whenever the block gives something different back.