### PR TITLE
add exists to check for the existence of a variable name

### DIFF
--- a/lib/kalculator/evaluator.rb
+++ b/lib/kalculator/evaluator.rb
@@ -86,6 +86,10 @@ class Kalculator
       Date.parse(value)
     end
 
+    def exists(_, variable_name)
+      @data_source.key?(variable_name)
+    end
+
     def if(_, condition, true_clause, false_clause)
       if evaluate(condition)
         evaluate(true_clause)

--- a/lib/kalculator/lexer.rb
+++ b/lib/kalculator/lexer.rb
@@ -25,6 +25,7 @@ class Kalculator
     rule(/contains/) { |t| :CONTAINS }
     rule(/count/)    { |t| :COUNT }
     rule(/date/)     { |t| :DATE }
+    rule(/exists/)   { |t| :EXISTS }
     rule(/if/)       { |t| :IF }
     rule(/max/)      { |t| :MAX }
     rule(/min/)      { |t| :MIN }

--- a/lib/kalculator/parser.rb
+++ b/lib/kalculator/parser.rb
@@ -22,6 +22,9 @@ class Kalculator
       clause('DATE LPAREN expression RPAREN') do |_, _, e0, _|
         [:date, e0]
       end
+      clause('EXISTS LPAREN IDENT RPAREN') do |_, _, n, _|
+        [:exists, n]
+      end
       clause('MAX LPAREN expression COMMA expression RPAREN') { |_, _, left, _, right, _| [:max, left, right] }
       clause('MIN LPAREN expression COMMA expression RPAREN') { |_, _, left, _, right, _| [:min, left, right] }
       clause('LPAREN expression RPAREN') { |_, expression, _| expression }

--- a/spec/exists_spec.rb
+++ b/spec/exists_spec.rb
@@ -1,0 +1,10 @@
+require "spec_helper"
+
+RSpec.describe "exists()" do
+  it "allows a formula to check for the existience of a variable" do
+    formula = "if(exists(Recurring), Recurring, false)"
+    expect(Kalculator.evaluate(formula, {"Recurring" => true})).to eq(true)
+    expect(Kalculator.evaluate(formula, {"Recurring" => false})).to eq(false)
+    expect(Kalculator.evaluate(formula, {})).to eq(false)
+  end
+end


### PR DESCRIPTION
Allow a formula to check for the existence of a variable before using it.