### PR TITLE
Introduce null

### DIFF
--- a/lib/kalculator/evaluator.rb
+++ b/lib/kalculator/evaluator.rb
@@ -124,6 +124,10 @@ class Kalculator
       !bool
     end
 
+    def null(_, _)
+      nil
+    end
+
     def number(_, number)
       number
     end

--- a/lib/kalculator/lexer.rb
+++ b/lib/kalculator/lexer.rb
@@ -16,6 +16,8 @@ class Kalculator
     rule(/<=/)       { :LTE      }
     rule(/==/)       { :EQ       }
     rule(/!=/)       { :NEQ      }
+    rule(/and/)      { :AND      }
+    rule(/or/)       { :OR       }
     rule(/AND/)      { :AND      }
     rule(/OR/)       { :OR       }
     rule(/!/)        { :BANG     }
@@ -36,6 +38,9 @@ class Kalculator
     rule(/true/)     { |t| :TRUE }
     rule(/false/)    { |t| :FALSE }
     rule(/null/)     { |t| :NULL }
+    rule(/TRUE/)     { |t| :TRUE }
+    rule(/FALSE/)    { |t| :FALSE }
+    rule(/NULL/)     { |t| :NULL }
     rule(/"[^"]*"/)  { |t| [:STRING, t[1..-2]] }
     rule(/[A-Za-z][A-Za-z0-9\._]*/) { |t| [:IDENT, t] }
   end

--- a/lib/kalculator/lexer.rb
+++ b/lib/kalculator/lexer.rb
@@ -35,6 +35,7 @@ class Kalculator
     rule(/sum/)      { |t| :SUM }
     rule(/true/)     { |t| :TRUE }
     rule(/false/)    { |t| :FALSE }
+    rule(/null/)     { |t| :NULL }
     rule(/"[^"]*"/)  { |t| [:STRING, t[1..-2]] }
     rule(/[A-Za-z][A-Za-z0-9\._]*/) { |t| [:IDENT, t] }
   end

--- a/lib/kalculator/parser.rb
+++ b/lib/kalculator/parser.rb
@@ -36,6 +36,7 @@ class Kalculator
       clause('IDENT') { |n| [:variable, n] }
       clause('TRUE') { |n| [:boolean, true] }
       clause('FALSE') { |n| [:boolean, false] }
+      clause('NULL') { |n| [:null, nil] }
 
       clause('expression GT expression') { |e0, _, e1| [:>, e0, e1] }
       clause('expression GTE expression') { |e0, _, e1| [:>=, e0, e1] }

--- a/spec/boolean_operators_spec.rb
+++ b/spec/boolean_operators_spec.rb
@@ -1,10 +1,12 @@
 RSpec.describe "Boolean Operators" do
   it "evaluates true" do
     expect(Kalculator.evaluate("true")).to be true
+    expect(Kalculator.evaluate("TRUE")).to be true
   end
 
   it "evaluates false" do
     expect(Kalculator.evaluate("false")).to be false
+    expect(Kalculator.evaluate("FALSE")).to be false
   end
 
   it "evaluates >" do
@@ -39,16 +41,16 @@ RSpec.describe "Boolean Operators" do
 
   it "evaluates AND" do
     expect(Kalculator.evaluate("true AND true")).to eq(true)
-    expect(Kalculator.evaluate("true AND false")).to eq(false)
+    expect(Kalculator.evaluate("true and false")).to eq(false)
     expect(Kalculator.evaluate("false AND false")).to eq(false)
-    expect(Kalculator.evaluate("A < 5 AND contains(B, C)", {"A" => 4, "B" => "abc", "C" => "b"})).to eq(true)
+    expect(Kalculator.evaluate("A < 5 and contains(B, C)", {"A" => 4, "B" => "abc", "C" => "b"})).to eq(true)
     expect(Kalculator.evaluate("A < 5 AND contains(B, C)", {"A" => 4, "B" => "abc", "C" => "z"})).to eq(false)
   end
 
   it "evaluates OR" do
     expect(Kalculator.evaluate("true OR true")).to eq(true)
-    expect(Kalculator.evaluate("true OR false")).to eq(true)
-    expect(Kalculator.evaluate("false OR false")).to eq(false)
+    expect(Kalculator.evaluate("true or false")).to eq(true)
+    expect(Kalculator.evaluate("false or false")).to eq(false)
     expect(Kalculator.evaluate("A < 5 OR contains(B, C)", {"A" => 6, "B" => "abc", "C" => "b"})).to eq(true)
     expect(Kalculator.evaluate("A < 5 OR contains(B, C)", {"A" => 6, "B" => "abc", "C" => "z"})).to eq(false)
   end

--- a/spec/null_spec.rb
+++ b/spec/null_spec.rb
@@ -1,0 +1,15 @@
+RSpec.describe "parsing and evaluating nulls" do
+  it "can parse a null" do
+    expect(Kalculator.evaluate("null")).to be_nil
+  end
+
+  it "can compare null" do
+    expect(Kalculator.evaluate("a == null", {"a" => nil})).to eq(true)
+    expect(Kalculator.evaluate("a == null", {"a" => 123})).to eq(false)
+  end
+
+  it "can match nil in a list" do
+    expect(Kalculator.evaluate("contains(list, null)", {"list" => [1, 2, nil]})).to eq(true)
+    expect(Kalculator.evaluate("contains(list, null)", {"list" => [1, 2, 3]})).to eq(false)
+  end
+end

--- a/spec/null_spec.rb
+++ b/spec/null_spec.rb
@@ -1,6 +1,7 @@
 RSpec.describe "parsing and evaluating nulls" do
   it "can parse a null" do
     expect(Kalculator.evaluate("null")).to be_nil
+    expect(Kalculator.evaluate("NULL")).to be_nil
   end
 
   it "can compare null" do


### PR DESCRIPTION
Allows the usage of `null` in formulas and also allows `true`/`false`/`null`/`and`/`or` to be upper-or-lower case.