### PR TITLE
fix bug with how we parse exists statements

### DIFF
--- a/lib/kalculator/evaluator.rb
+++ b/lib/kalculator/evaluator.rb
@@ -86,8 +86,9 @@ class Kalculator
       Date.parse(value)
     end
 
-    def exists(_, variable_name)
-      @data_source.key?(variable_name)
+    def exists(_, variable)
+      (_variable, name) = variable
+      @data_source.key?(name)
     end
 
     def if(_, condition, true_clause, false_clause)

--- a/lib/kalculator/parser.rb
+++ b/lib/kalculator/parser.rb
@@ -23,7 +23,7 @@ class Kalculator
         [:date, e0]
       end
       clause('EXISTS LPAREN IDENT RPAREN') do |_, _, n, _|
-        [:exists, n]
+        [:exists, [:variable, n]]
       end
       clause('MAX LPAREN expression COMMA expression RPAREN') { |_, _, left, _, right, _| [:max, left, right] }
       clause('MIN LPAREN expression COMMA expression RPAREN') { |_, _, left, _, right, _| [:min, left, right] }

--- a/spec/exists_spec.rb
+++ b/spec/exists_spec.rb
@@ -1,6 +1,10 @@
 require "spec_helper"
 
 RSpec.describe "exists()" do
+  it "can parse exists statements" do
+    expect(Kalculator.parse("exists(ohai)")).to eq([:exists, [:variable, "ohai"]])
+  end
+
   it "allows a formula to check for the existience of a variable" do
     formula = "if(exists(Recurring), Recurring, false)"
     expect(Kalculator.evaluate(formula, {"Recurring" => true})).to eq(true)

--- a/spec/transforms_spec.rb
+++ b/spec/transforms_spec.rb
@@ -47,4 +47,13 @@ RSpec.describe Kalculator::Transform do
       ]
     ])
   end
+
+  it "can replaces variables inside of exists calls" do
+    ast = Kalculator.parse("exists(ohai)")
+    new_ast = Kalculator::Transform.run(ast) do |node|
+      next node unless node.is_a?(Array) && node.first == :variable
+      [:variable, "wat"]
+    end
+    expect(new_ast).to eq([:exists, [:variable, "wat"]])
+  end
 end


### PR DESCRIPTION
Make sure that variables inside of an `exists` statement are represented as variables in the AST. That way they can still be transformed