### PR TITLE
Arbitrary functions

### DIFF
--- a/lib/kalculator.rb
+++ b/lib/kalculator.rb
@@ -1,4 +1,5 @@
 require "rltk"
+require "kalculator/built_in_functions"
 require "kalculator/data_sources"
 require "kalculator/errors"
 require "kalculator/evaluator"

--- a/lib/kalculator.rb
+++ b/lib/kalculator.rb
@@ -11,8 +11,8 @@ require "kalculator/transform"
 require "kalculator/version"
 
 class Kalculator
-  def self.evaluate(formula, data_source = {})
-    Kalculator::Formula.new(formula).evaluate(data_source)
+  def self.evaluate(formula, data_source = {}, custom_functions = {})
+    Kalculator::Formula.new(formula).evaluate(data_source, custom_functions)
   end
 
   def self.new(*args)

--- a/lib/kalculator/built_in_functions.rb
+++ b/lib/kalculator/built_in_functions.rb
@@ -14,5 +14,17 @@ class Kalculator
         raise TypeError, "contains only works with strings or lists, got #{collection.inspect} and #{item.inspect}"
       end
     end
+
+    def self.date(str)
+      raise TypeError, "date only works with Strings, got #{str.inspect}" unless str.is_a?(String)
+      Date.parse(str)
+    end
+
+    def self.sum(array)
+      unless array.is_a?(Array) && array.all?{|n| n.is_a?(Numeric)}
+        raise TypeError, "sum only works with lists of numbers, got #{array.inspect}"
+      end
+      array.inject(0){|sum, num| sum + num}
+    end
   end
 end

--- a/lib/kalculator/built_in_functions.rb
+++ b/lib/kalculator/built_in_functions.rb
@@ -1,11 +1,6 @@
 class Kalculator
-  module BuiltInFunctions
-    def self.count(collection)
-      raise TypeError, "count only works with Enumerable types, got #{collection.inspect}" unless collection.is_a?(Enumerable)
-      collection.count
-    end
-
-    def self.contains(collection, item)
+  BUILT_IN_FUNCTIONS = {
+    ["contains", 2] => lambda { |collection, item|
       if collection.is_a?(Array)
         collection.include?(item)
       elsif collection.is_a?(String) && item.is_a?(String)
@@ -13,18 +8,20 @@ class Kalculator
       else
         raise TypeError, "contains only works with strings or lists, got #{collection.inspect} and #{item.inspect}"
       end
-    end
-
-    def self.date(str)
+    },
+    ["count", 1] => lambda { |list|
+      raise TypeError, "count only works with Enumerable types, got #{list.inspect}" unless list.is_a?(Enumerable)
+      list.count
+    },
+    ["date", 1] => lambda { |str|
       raise TypeError, "date only works with Strings, got #{str.inspect}" unless str.is_a?(String)
       Date.parse(str)
-    end
-
-    def self.sum(array)
-      unless array.is_a?(Array) && array.all?{|n| n.is_a?(Numeric)}
-        raise TypeError, "sum only works with lists of numbers, got #{array.inspect}"
+    },
+    ["sum", 1] => lambda { |list|
+      unless list.is_a?(Array) && list.all?{|n| n.is_a?(Numeric)}
+        raise TypeError, "sum only works with lists of numbers, got #{list.inspect}"
       end
-      array.inject(0){|sum, num| sum + num}
-    end
-  end
+      list.inject(0){|sum, num| sum + num}
+    },
+  }.freeze
 end

--- a/lib/kalculator/built_in_functions.rb
+++ b/lib/kalculator/built_in_functions.rb
@@ -1,0 +1,18 @@
+class Kalculator
+  module BuiltInFunctions
+    def self.count(collection)
+      raise TypeError, "count only works with Enumerable types, got #{collection.inspect}" unless collection.is_a?(Enumerable)
+      collection.count
+    end
+
+    def self.contains(collection, item)
+      if collection.is_a?(Array)
+        collection.include?(item)
+      elsif collection.is_a?(String) && item.is_a?(String)
+        collection.include?(item)
+      else
+        raise TypeError, "contains only works with strings or lists, got #{collection.inspect} and #{item.inspect}"
+      end
+    end
+  end
+end

--- a/lib/kalculator/built_in_functions.rb
+++ b/lib/kalculator/built_in_functions.rb
@@ -17,6 +17,16 @@ class Kalculator
       raise TypeError, "date only works with Strings, got #{str.inspect}" unless str.is_a?(String)
       Date.parse(str)
     },
+    ["max", 2] => lambda { |left, right|
+      raise TypeError, "max only works with numbers, got #{left.inspect}" unless left.is_a?(Numeric)
+      raise TypeError, "max only works with numbers, got #{right.inspect}" unless right.is_a?(Numeric)
+      [left, right].max
+    },
+    ["min", 2] => lambda { |left, right|
+      raise TypeError, "min only works with numbers, got #{left.inspect}" unless left.is_a?(Numeric)
+      raise TypeError, "min only works with numbers, got #{right.inspect}" unless right.is_a?(Numeric)
+      [left, right].min
+    },
     ["sum", 1] => lambda { |list|
       unless list.is_a?(Array) && list.all?{|n| n.is_a?(Numeric)}
         raise TypeError, "sum only works with lists of numbers, got #{list.inspect}"

--- a/lib/kalculator/errors.rb
+++ b/lib/kalculator/errors.rb
@@ -1,5 +1,6 @@
 class Kalculator
   class Error < ::StandardError; end
   class TypeError < Error; end
+  class UndefinedFunctionError < Error; end
   class UndefinedVariableError < Error; end
 end

--- a/lib/kalculator/evaluator.rb
+++ b/lib/kalculator/evaluator.rb
@@ -88,22 +88,6 @@ class Kalculator
       expressions.map{|expression| evaluate(expression) }
     end
 
-    def max(_, left, right)
-      left = evaluate(left)
-      right = evaluate(right)
-      raise TypeError, "max only works with numbers, got #{left.inspect}" unless left.is_a?(Numeric)
-      raise TypeError, "max only works with numbers, got #{right.inspect}" unless right.is_a?(Numeric)
-      [left, right].max
-    end
-
-    def min(_, left, right)
-      left = evaluate(left)
-      right = evaluate(right)
-      raise TypeError, "min only works with numbers, got #{left.inspect}" unless left.is_a?(Numeric)
-      raise TypeError, "min only works with numbers, got #{right.inspect}" unless right.is_a?(Numeric)
-      [left, right].min
-    end
-
     def not(_, expression)
       bool = evaluate(expression)
       raise TypeError, "! only works with booleans, got #{bool.inspect}" unless bool === true || bool === false

--- a/lib/kalculator/evaluator.rb
+++ b/lib/kalculator/evaluator.rb
@@ -2,8 +2,9 @@ require "date"
 
 class Kalculator
   class Evaluator
-    def initialize(data_source)
+    def initialize(data_source, custom_functions = {})
       @data_source = data_source
+      @functions = Kalculator::BUILT_IN_FUNCTIONS.merge(custom_functions)
     end
 
     def evaluate(ast)
@@ -69,7 +70,7 @@ class Kalculator
 
     def fn_call(_, fn_name, expressions)
       key = [fn_name, expressions.count]
-      fn = Kalculator::BUILT_IN_FUNCTIONS[key]
+      fn = @functions[key]
       raise UndefinedFunctionError, "no such function #{fn_name}/#{expressions.count}" if fn.nil?
       args = expressions.map{|expression| evaluate(expression) }
       return fn.call(*args)

--- a/lib/kalculator/evaluator.rb
+++ b/lib/kalculator/evaluator.rb
@@ -2,21 +2,6 @@ require "date"
 
 class Kalculator
   class Evaluator
-    FUNCTIONS = {
-      ["contains", 2] => lambda { |collection, item|
-        Kalculator::BuiltInFunctions.contains(collection, item)
-      },
-      ["count", 1] => lambda { |list|
-        Kalculator::BuiltInFunctions.count(list)
-      },
-      ["date", 1] => lambda { |str|
-        Kalculator::BuiltInFunctions.date(str)
-      },
-      ["sum", 1] => lambda { |array|
-        Kalculator::BuiltInFunctions.sum(array)
-      }
-    }
-
     def initialize(data_source)
       @data_source = data_source
     end
@@ -84,8 +69,8 @@ class Kalculator
 
     def fn_call(_, fn_name, expressions)
       key = [fn_name, expressions.count]
-      fn = FUNCTIONS[key]
-      raise UndefinedFunctionError, "no such function #{fn_name}/#{args.count}" if fn.nil?
+      fn = Kalculator::BUILT_IN_FUNCTIONS[key]
+      raise UndefinedFunctionError, "no such function #{fn_name}/#{expressions.count}" if fn.nil?
       args = expressions.map{|expression| evaluate(expression) }
       return fn.call(*args)
     end

--- a/lib/kalculator/evaluator.rb
+++ b/lib/kalculator/evaluator.rb
@@ -9,6 +9,12 @@ class Kalculator
       ["count", 1] => lambda { |list|
         Kalculator::BuiltInFunctions.count(list)
       },
+      ["date", 1] => lambda { |str|
+        Kalculator::BuiltInFunctions.date(str)
+      },
+      ["sum", 1] => lambda { |array|
+        Kalculator::BuiltInFunctions.sum(array)
+      }
     }
 
     def initialize(data_source)
@@ -69,12 +75,6 @@ class Kalculator
 
     def boolean(_, boolean)
       boolean
-    end
-
-    def date(_, expression)
-      value = evaluate(expression)
-      raise TypeError, "date only works with Strings, got #{value.inspect}" unless value.is_a?(String)
-      Date.parse(value)
     end
 
     def exists(_, variable)
@@ -138,14 +138,6 @@ class Kalculator
 
     def string(_, string)
       string
-    end
-
-    def sum(_, array)
-      array = evaluate(array)
-      unless array.is_a?(Array) && array.all?{|n| n.is_a?(Numeric)}
-        raise TypeError, "sum only works with lists of numbers, got #{array.inspect}"
-      end
-      array.inject(0){|sum, num| sum + num}
     end
 
     def variable(_, name)

--- a/lib/kalculator/formula.rb
+++ b/lib/kalculator/formula.rb
@@ -7,8 +7,8 @@ class Kalculator
       @string = string
     end
 
-    def evaluate(data_source = {})
-      Kalculator::Evaluator.new(data_source).evaluate(ast)
+    def evaluate(data_source = {}, custom_functions = {})
+      Kalculator::Evaluator.new(data_source, custom_functions).evaluate(ast)
     end
   end
 end

--- a/lib/kalculator/lexer.rb
+++ b/lib/kalculator/lexer.rb
@@ -29,8 +29,6 @@ class Kalculator
     rule(/\-?\d+\.\d+/) { |t| [:NUMBER, t.to_f] }
     rule(/exists/)   { |t| :EXISTS }
     rule(/if/)       { |t| :IF }
-    rule(/max/)      { |t| :MAX }
-    rule(/min/)      { |t| :MIN }
     rule(/true/)     { |t| :TRUE }
     rule(/false/)    { |t| :FALSE }
     rule(/null/)     { |t| :NULL }

--- a/lib/kalculator/lexer.rb
+++ b/lib/kalculator/lexer.rb
@@ -27,8 +27,6 @@ class Kalculator
     rule(/\-?\d+/)      { |t| [:NUMBER, t.to_i] }
     rule(/\-?\.\d+/)    { |t| [:NUMBER, t.to_f] }
     rule(/\-?\d+\.\d+/) { |t| [:NUMBER, t.to_f] }
-    rule(/contains/) { |t| :CONTAINS }
-    rule(/count/)    { |t| :COUNT }
     rule(/date/)     { |t| :DATE }
     rule(/exists/)   { |t| :EXISTS }
     rule(/if/)       { |t| :IF }

--- a/lib/kalculator/lexer.rb
+++ b/lib/kalculator/lexer.rb
@@ -27,12 +27,10 @@ class Kalculator
     rule(/\-?\d+/)      { |t| [:NUMBER, t.to_i] }
     rule(/\-?\.\d+/)    { |t| [:NUMBER, t.to_f] }
     rule(/\-?\d+\.\d+/) { |t| [:NUMBER, t.to_f] }
-    rule(/date/)     { |t| :DATE }
     rule(/exists/)   { |t| :EXISTS }
     rule(/if/)       { |t| :IF }
     rule(/max/)      { |t| :MAX }
     rule(/min/)      { |t| :MIN }
-    rule(/sum/)      { |t| :SUM }
     rule(/true/)     { |t| :TRUE }
     rule(/false/)    { |t| :FALSE }
     rule(/null/)     { |t| :NULL }

--- a/lib/kalculator/parser.rb
+++ b/lib/kalculator/parser.rb
@@ -13,8 +13,6 @@ class Kalculator
       clause('EXISTS LPAREN IDENT RPAREN') do |_, _, n, _|
         [:exists, [:variable, n]]
       end
-      clause('MAX LPAREN expression COMMA expression RPAREN') { |_, _, left, _, right, _| [:max, left, right] }
-      clause('MIN LPAREN expression COMMA expression RPAREN') { |_, _, left, _, right, _| [:min, left, right] }
       clause('LPAREN expression RPAREN') { |_, expression, _| expression }
       clause('LBRACKET expressions RBRACKET') { |_, expressions, _| [:list, expressions] }
       clause('IDENT LPAREN expressions RPAREN') { |fn_name, _, expressions, _| [:fn_call, fn_name, expressions] }

--- a/lib/kalculator/parser.rb
+++ b/lib/kalculator/parser.rb
@@ -7,17 +7,11 @@ class Kalculator
     #Left     600 '.'.
 
     production(:expression) do
-      clause('CONTAINS LPAREN expression COMMA expression RPAREN') do |_, _, collection, _, item, _|
-        [:contains, collection, item]
-      end
       clause('IF LPAREN expression COMMA expression COMMA expression RPAREN') do |_, _, condition, _, true_clause, _, false_clause, _|
         [:if, condition, true_clause, false_clause]
       end
       clause('SUM LPAREN expression RPAREN') do |_, _, e0, _|
         [:sum, e0]
-      end
-      clause('COUNT LPAREN expression RPAREN') do |_, _, e0, _|
-        [:count, e0]
       end
       clause('DATE LPAREN expression RPAREN') do |_, _, e0, _|
         [:date, e0]
@@ -29,6 +23,7 @@ class Kalculator
       clause('MIN LPAREN expression COMMA expression RPAREN') { |_, _, left, _, right, _| [:min, left, right] }
       clause('LPAREN expression RPAREN') { |_, expression, _| expression }
       clause('LBRACKET expressions RBRACKET') { |_, expressions, _| [:list, expressions] }
+      clause('IDENT LPAREN expressions RPAREN') { |fn_name, _, expressions, _| [:fn_call, fn_name, expressions] }
 
       clause('NUMBER') { |n| [:number, n] }
       clause('PERCENT') { |n| [:percent, n] }

--- a/lib/kalculator/parser.rb
+++ b/lib/kalculator/parser.rb
@@ -10,12 +10,6 @@ class Kalculator
       clause('IF LPAREN expression COMMA expression COMMA expression RPAREN') do |_, _, condition, _, true_clause, _, false_clause, _|
         [:if, condition, true_clause, false_clause]
       end
-      clause('SUM LPAREN expression RPAREN') do |_, _, e0, _|
-        [:sum, e0]
-      end
-      clause('DATE LPAREN expression RPAREN') do |_, _, e0, _|
-        [:date, e0]
-      end
       clause('EXISTS LPAREN IDENT RPAREN') do |_, _, n, _|
         [:exists, [:variable, n]]
       end

--- a/lib/kalculator/transform.rb
+++ b/lib/kalculator/transform.rb
@@ -2,13 +2,18 @@ class Kalculator
   module Transform
     def self.run(node, &block)
       new_node = yield node
-      return new_node if is_terminal?(new_node)
-      args = new_node[1..-1].map{ |arg| run(arg, &block) }
-      args.unshift(new_node.first)
+      if is_terminal?(new_node)
+        new_node
+      elsif new_node.first.is_a?(Symbol)
+        args = new_node[1..-1].map{ |arg| run(arg, &block) }
+        args.unshift(new_node.first)
+      else
+        new_node.map{|node| run(node, &block) }
+      end
     end
 
     def self.is_terminal?(node)
-      return false if node.is_a?(Array) && node.first.is_a?(Symbol)
+      return false if node.is_a?(Array)
       true
     end
   end

--- a/spec/built_in_functions_spec.rb
+++ b/spec/built_in_functions_spec.rb
@@ -111,4 +111,10 @@ RSpec.describe Kalculator::Formula do
       }.to raise_error(Kalculator::TypeError, "min only works with numbers, got [1, 2, 3]")
     end
   end
+
+  it "raises a specific error for undefined functions" do
+    expect {
+      Kalculator.evaluate("wat(123)")
+    }.to raise_error(Kalculator::UndefinedFunctionError, "no such function wat/1")
+  end
 end

--- a/spec/custom_functions_spec.rb
+++ b/spec/custom_functions_spec.rb
@@ -1,0 +1,11 @@
+require "spec_helper"
+
+RSpec.describe "custom functions" do
+  it "can accept custom functions" do
+    custom = {
+      ["wat", 1] => lambda{ |num| num * 2 }
+    }
+    result = Kalculator.evaluate("wat(5)", {}, custom)
+    expect(result).to eq(10)
+  end
+end

--- a/spec/transforms_spec.rb
+++ b/spec/transforms_spec.rb
@@ -4,13 +4,25 @@ RSpec.describe Kalculator::Transform do
   it "can walk through an entire AST" do
     ast = Kalculator.parse("sum(List)")
     new_ast = Kalculator::Transform.run(ast) do |node|
-      if node == [:variable, "List"]
-        [:list, [[:number, 1], [:number, 2]]]
-      else
-        node
-      end
+      next [:list, [[:number, 1], [:number, 2]]] if node == [:variable, "List"]
+      node
     end
-    expect(new_ast).to eq([:sum, [:list, [[:number, 1], [:number, 2]]]])
+    expect(new_ast).to eq([:fn_call, "sum", [[:list, [[:number, 1], [:number, 2]]]]])
+  end
+
+  it "can replace items in a list" do
+    ast = Kalculator.parse("[Foo, 5, \"hi\"]")
+    new_ast = Kalculator::Transform.run(ast) do |node|
+      next [:variable, "Bar"] if node == [:variable, "Foo"]
+      next 6 if node == 5
+      next [:string, "ohai"] if node == [:string, "hi"]
+      node
+    end
+    expect(new_ast).to eq([:list, [
+      [:variable, "Bar"],
+      [:number, 6],
+      [:string, "ohai"]
+    ]])
   end
 
   it "can replace nested nodes" do


### PR DESCRIPTION
@casejamesc @jeron @camkidm if any of you get a chance to check this, I think it would be really helpful to double-check my thinking. This change makes it so that the calculator gem can be extended with any custom functions. Rather than have hardcoded rules about people being able to write `sum(...)` in their formulas, we just recognize anything that looks like `<an identifier>(...)` as a function call. Then it looks in its list of functions (by name and number of arguments) to see if it can call that function. This way we will be able to add more functions as-needed on the Spiff side of things without releasing new versions of `kalculator`.